### PR TITLE
initialize headers to {} if we need to copy some. 

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -111,10 +111,9 @@ function request(options, a, b) {
 	}
 
 	/* apply header overrides */
-	if(typeof o.headers != "undefined"){
+	if(typeof o.headers != "undefined" && typeof options.headers == "undefined")
 		options.headers = {};
-		_.extend(options.headers, o.headers);
-	}
+	_.extend(options.headers, o.headers);
 	_.extend(options, _.pick(o, ['auth', 'agent']));
 
 	/* for debugging, method to get options and return */


### PR DESCRIPTION
Not sure if this is a bug in underscore, but without this I got: 

najax/node_modules/underscore/underscore.js:822
          obj[prop] = source[prop];
                    ^
TypeError: Cannot set property '...' of undefined
