### PR TITLE
Add responseText to jqXHR

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -164,6 +164,8 @@ function request(options, a, b) {
 				data += d;
 		});
 		res.on('end', function() {
+			jqXHR.responseText = data;
+			
 			if (o.dataType === 'json') {
 				//replace control characters
 				try {


### PR DESCRIPTION
Add `responseText` to the `jqXHR` object for accessing on success and error callbacks, e.g.
````javascript
najax({url: url}).success(function (response) {
    ...
}).error(function(xhr) {
    myErrorCallback(xhr.responseText);
});
````