### PR TITLE
Support legacy jquery options.type parameter (+jshint)

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -1,3 +1,4 @@
+/*jshint latedef: nofunc */
 /*
  * najax
  * https://github.com/alanclarke/najax
@@ -43,7 +44,7 @@ function _parseOptions(options, a, b){
 _.each('get post put delete'.split(' '),function(method){
 	najax[method] = module.exports[method] = function(options, a, b) {
 		var opts = _parseOptions(options, a, b);
-		opts.method  = method.toUpperCase()
+		opts.method  = method.toUpperCase();
 		return najax(opts);
 	};
 });
@@ -58,6 +59,8 @@ function request(options, a, b) {
 		-function(opts)
 	*/
 
+    //support legacy jquery options.type
+    options.method = options.method || options.type; 
 
 	if (_.isString(options) || _.isFunction(a)) {
 		return request(_parseOptions(options, a, b));
@@ -75,7 +78,7 @@ function request(options, a, b) {
 	// and the data is not already a string
 	// https://github.com/jquery/jquery/blob/master/src/ajax.js#L518
 	if (o.data && o.processData && o.method === 'GET') {
-		o.data = querystring.stringify(o.data)
+		o.data = querystring.stringify(o.data);
 	} else if (o.data && o.processData && typeof o.data !== 'string' && o.method !== 'GET') {
 		switch (o.contentType) {
 			case 'application/json': o.data = JSON.stringify(o.data); break;


### PR DESCRIPTION
options.type is an alias for options.method and required for some code
expecting earlier versions of jquery.

Also did some minor jshint cleanup so the grunt check returned cleanly. Did not seem important/big enough to write unit tests, but I can if you'd like. 