### PR TITLE
Add support for setRequestHeader and beforeSend

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -16,7 +16,10 @@ var defaults = {
   processData: true,
   data: '',
   contentType: 'application/x-www-form-urlencoded',
-  headers: {}
+  headers: {},
+  setRequestHeader: function (name, value) {
+    this.headers[name] = value
+  }
 }
 
 /*
@@ -67,6 +70,10 @@ function najax (uri, options, callback) {
         'Content-Length': Buffer.byteLength(o.data)
       }, o.headers)
     }
+  }
+
+  if (o.beforeSend) {
+    o.beforeSend(o)
   }
 
   options = {

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -225,6 +225,23 @@ describe('data', function (next) {
       }
     }, createSuccess(done))
   })
+
+  it('should support beforeSend and setRequestHeader', function (done) {
+    nock('http://www.example.com')
+      .post('/', data)
+      .matchHeader('Content-Type', 'application/xml;charset=utf-8')
+      .matchHeader('Content-Length', 7)
+      .matchHeader('Accepts', 'application/vnd.json+api')
+      .reply(200, 'ok')
+
+    najax.post('http://www.example.com', {
+      data: JSON.stringify(data),
+      contentType: 'application/xml',
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('Accepts', 'application/vnd.json+api')
+      }
+    }, createSuccess(done))
+  })
 })
 
 describe('timeout', function () {


### PR DESCRIPTION
Having an issue with Ember Fastboot (which uses `najax`). The adapter for JSON API in Ember Data uses `beforeSend` option to set headers on the jqXHR object. This adds support for `beforeSend` and also `setRequestHeader` for the mock jqXHR object