### PR TITLE
Making parse more robust

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -173,6 +173,7 @@ function najax (uri, options, callback) {
         jqXHR.statusText = statusText
 
         if (_.isFunction(o.success)) o.success(data, statusText, jqXHR)
+        if (_.isFunction(o.complete)) o.complete(jqXHR)
         // success, statusText, jqXHR
         dfd.resolve(data, statusText, jqXHR)
       } else {

--- a/lib/najax.js
+++ b/lib/najax.js
@@ -146,7 +146,7 @@ function najax (uri, options, callback) {
       if (o.dataType === 'json' || o.dataType === 'jsonp') {
         // replace control characters
         try {
-          data = JSON.parse(data.replace(/[\cA-\cZ]/gi, ''))
+          data = _.attempt(JSON.parse.bind(null, data.replace(/[\cA-\cZ]/gi, '')))
         } catch (e) {
           return errorHandler(e)
         }

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -63,6 +63,19 @@ describe('url', function (next) {
     najax({ url: 'http://www.example.com' }, createSuccess(done))
   })
 
+  it('should not fail when result is broken JSON', function (done) {
+    mockPlain('get')
+    najax({url: 'http://www.example.com', dataType: 'json'}, jsonError(done))
+  })
+
+  it('should succeed when result is good JSON', function (done) {
+    nock('http://www.example.com')
+      .get('/')
+      .reply(200, {"test": "ok"})
+
+    najax({url: 'http://www.example.com', dataType: 'json'}, jsonSuccess(done))
+  })
+
   it('should parse auth from the url', function (done) {
     mockAuth('get')
     najax({ url: 'http://' + authString + '@www.example.com' }, createSuccess(done))
@@ -290,6 +303,22 @@ describe('headers', function () {
 function createSuccess (done) {
   return function (data, statusText) {
     expect(data).to.equal('ok')
+    expect(statusText).to.equal('success')
+    done()
+  }
+}
+
+function jsonSuccess (done) {
+  return function (data, statusText) {
+    expect(data.test).to.equal('ok')
+    expect(statusText).to.equal('success')
+    done()
+  }
+}
+
+function jsonError (done) {
+  return function (data, statusText) {
+    expect(data.test).to.be.undefined
     expect(statusText).to.equal('success')
     done()
   }

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -71,7 +71,7 @@ describe('url', function (next) {
   it('should succeed when result is good JSON', function (done) {
     nock('http://www.example.com')
       .get('/')
-      .reply(200, {"test": "ok"})
+      .reply(200, {'test': 'ok'})
 
     najax({url: 'http://www.example.com', dataType: 'json'}, jsonSuccess(done))
   })


### PR DESCRIPTION
This was failing when the content of JSON responses was not JSON. 
