### PR TITLE
improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,36 +10,14 @@ jQuery ajax-stye http requests in node
 
 jQuery ajax is stupid simple. This project provides a lightweight wrapper for the nodejs http request object that enables jquery ajax style syntax when making serverside requests to other webpages in node.js
 
-It features very flexible method overloads to suit various styles, including with jquery style deferreds.
-
-It seamlessly handles ssl and makes some reasonable assumptions based on inputs but as usual everything can be overridden by passing an options object.
-
-## Changelog
-
-### 0.5.0
-
-  * Support gzip and deflate.
-  * End support for Node 0.10.
-
-### 0.3.0
-
-  * switched from underscore to lodash
-
-### 0.2.0
-
-**Breaking changes!**
-
-  * `success` and `error` callback arguments are now in [jQuery.ajax](https://api.jquery.com/jquery.ajax/) order and format.
-  * `contentType` must now be the full string, i.e. `application/json`, not just `json`.
-  * Undocumented `encoder` option deprecated.  Any object can already override its own `toString()`.
-  * CRLF (`\n`) removed from end of POST message body.  It did not match HTTP spec.
+In addition to najax.get, , handles ssl and makes some reasonable assumptions based on inputs and everything can be overridden by passing an options object.
 
 ## Getting Started
 Install the module with: `npm install najax`
 
 ```javascript
 var najax = $ = require('najax')
-najax('http://www.google.com', callback)
+$.get('http://www.google.com', callback)
 najax('http://www.google.com', { type: 'POST' }, callback)
 najax({ url: 'http://www.google.com', type: 'POST', success: callback })
 najax({ url: 'http://www.google.com', type: 'POST' })

--- a/lib/najax.js
+++ b/lib/najax.js
@@ -72,9 +72,7 @@ function najax (uri, options, callback) {
     }
   }
 
-  if (o.beforeSend) {
-    o.beforeSend(o)
-  }
+  if (o.beforeSend) o.beforeSend(o)
 
   options = {
     host: l.hostname,
@@ -120,20 +118,12 @@ function najax (uri, options, callback) {
     abort: notImplemented('abort')
   }
 
-  function errorHandler (e) {
-    // Set data for the fake xhr object
-    jqXHR.responseText = e instanceof Error ? e.stack : e
-    if (_.isFunction(o.error)) o.error(jqXHR, 'error', e)
-    // jqXHR, statusText, error
-    dfd.reject(jqXHR, 'error', e)
-  }
-
   var req = (ssl ? https : http).request(options, function (res) {
     // Allow getting Response Headers from the XMLHTTPRequest object
-    dfd.getResponseHeader = jqXHR.getResponseHeader = function (header) {
+    dfd.getResponseHeader = jqXHR.getResponseHeader = function getResponseHeader (header) {
       return res.headers[header.toLowerCase()]
     }
-    dfd.getAllResponseHeaders = jqXHR.getAllResponseHeaders = function () {
+    dfd.getAllResponseHeaders = jqXHR.getAllResponseHeaders = function getAllResponseHeaders () {
       var headers = []
       for (var key in res.headers) {
         headers.push(key + ': ' + res.headers[key])
@@ -148,17 +138,17 @@ function najax (uri, options, callback) {
         try {
           data = JSON.parse(data.replace(/[\cA-\cZ]/gi, ''))
         } catch (e) {
-          return errorHandler(e)
+          return onError(e)
         }
       }
 
       var statusCode = res.statusCode
-      var statusText = 'success'
+      jqXHR.statusText = 'success'
 
       if (statusCode === 204 || options.method === 'HEAD') {
-        statusText = 'nocontent'
+        jqXHR.statusText = 'nocontent'
       } else if (statusCode === 304) {
-        statusText = 'notmodified'
+        jqXHR.statusText = 'notmodified'
       }
 
       // Determine if successful
@@ -169,16 +159,14 @@ function najax (uri, options, callback) {
       jqXHR.status = statusCode
 
       if (isSuccess) {
-        // Set data for the fake xhr object
-        jqXHR.statusText = statusText
         // success, statusText, jqXHR
-        dfd.resolve(data, statusText, jqXHR)
+        dfd.resolve(data, jqXHR.statusText, jqXHR)
       } else {
         // jqXHR, statusText, error
         // When an HTTP error occurs, errorThrown receives the textual portion of the
         // HTTP status, such as "Not Found" or "Internal Server Error."
-        statusText = 'error'
-        dfd.reject(jqXHR, statusText, http.STATUS_CODES[statusCode])
+        jqXHR.statusText = 'error'
+        onError(new Error(http.STATUS_CODES[statusCode]))
       }
     }
     var chunks = []
@@ -189,7 +177,7 @@ function najax (uri, options, callback) {
       if (encoding === 'gzip') {
         zlib.gunzip(buffer, function (err, buffer) {
           if (err) {
-            errorHandler(err)
+            onError(err)
           } else {
             dataHandler(buffer.toString())
           }
@@ -197,7 +185,7 @@ function najax (uri, options, callback) {
       } else if (encoding === 'deflate') {
         zlib.inflate(buffer, function (err, buffer) {
           if (err) {
-            errorHandler(err)
+            onError(err)
           } else {
             dataHandler(buffer.toString())
           }
@@ -209,13 +197,21 @@ function najax (uri, options, callback) {
   })
 
   // ERROR
-  req.on('error', errorHandler)
+  req.on('error', onError)
+
+  function onError (e) {
+    // Set data for the fake xhr object
+    if (jqXHR.statusText === 'error') jqXHR.responseText = e.stack
+    // jqXHR, statusText, error
+    dfd.reject(jqXHR, jqXHR.statusText, e)
+  }
 
   // SET TIMEOUT
   if (o.timeout && o.timeout > 0) {
     req.setTimeout(o.timeout, function () {
       req.abort()
-      dfd.reject(jqXHR, 'timeout')
+      jqXHR.statusText = 'timeout'
+      onError(new Error('timeout'))
     })
   }
 
@@ -233,15 +229,17 @@ function najax (uri, options, callback) {
   return dfd
 }
 
-najax.defaults = function (opts) {
+najax.defaults = function defaults (opts) {
   return _.extend(defaults, opts)
 }
 
 /* auto rest interface go! */
-_.each(['GET', 'POST', 'PUT', 'DELETE'], function (method) {
-  najax[method.toLowerCase()] = function (uri, options, callback) {
+_.each(['GET', 'POST', 'PUT', 'DELETE'], handleMethod)
+
+function handleMethod (method) {
+  najax[method.toLowerCase()] = function methodHandler (uri, options, callback) {
     return najax(_.extend(parseOptions(uri, options, callback), { method: method }))
   }
-})
+}
 
 module.exports = najax

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -272,8 +272,8 @@ describe('timeout', function () {
       .socketDelay(1000)
       .reply(200, 'ok')
     var opts = { timeout: 1, error: false }
-    najax.post('http://www.example.com', opts)
-      .always(function (data, statusText) {
+    return najax.post('http://www.example.com', opts)
+      .error(function (data, statusText, e) {
         expect(statusText).to.eql('timeout')
         done()
       })


### PR DESCRIPTION
@devlato I improved the error handling a bit here, however I suspect the issue is in the conversion from  jquery Deferreds to standard js promises? As you can see in the timeout test, the error handler is called with the signature: errorHandler(data, statusText, error), which was consistent with the jquery api at the time that code was written, but is different from a typical js promise, which only accepts one argument