### PR TITLE
added console error logging

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -123,6 +123,7 @@ function najax (uri, options, callback) {
   function errorHandler (e) {
     // Set data for the fake xhr object
     jqXHR.responseText = e.stack
+    console.error('najax: error raised - ' + e.stack)
     if (_.isFunction(o.error)) o.error(jqXHR, 'error', e)
     // jqXHR, statusText, error
     dfd.reject(jqXHR, 'error', e)


### PR DESCRIPTION
I had some certificate errors, but looking at the output generated from najax it was VERY difficult to figure out what was going on:

```
najax: method jqXHR."getAllResponseHeaders" not implemented
Trace
    at Object.getAllResponseHeaders (/Users/hassan/codez/najax/lib/najax.js:109:15)
    at ClientRequest.errorHandler (/Users/hassan/codez/najax/lib/najax.js:126:34)
    at ClientRequest.emit (events.js:107:17)
    at TLSSocket.socketErrorListener (_http_client.js:272:9)
    at TLSSocket.emit (events.js:129:20)
    at TLSSocket.<anonymous> (_tls_wrap.js:940:18)
    at TLSSocket.emit (events.js:104:17)
    at TLSSocket._finishInit (_tls_wrap.js:458:8)
```

This PR renders the same condition as following in the error output, which greatly improved understanding of what was going on:

```
najax: error raised - Error: unable to verify the first certificate
    at Error (native)
    at TLSSocket.<anonymous> (_tls_wrap.js:927:36)
    at TLSSocket.emit (events.js:104:17)
    at TLSSocket._finishInit (_tls_wrap.js:458:8)
najax: method jqXHR."getAllResponseHeaders" not implemented
Trace
    at Object.getAllResponseHeaders (/Users/hassan/codez/najax/lib/najax.js:109:15)
    at ClientRequest.errorHandler (/Users/hassan/codez/najax/lib/najax.js:127:34)
    at ClientRequest.emit (events.js:107:17)
    at TLSSocket.socketErrorListener (_http_client.js:272:9)
    at TLSSocket.emit (events.js:129:20)
    at TLSSocket.<anonymous> (_tls_wrap.js:940:18)
    at TLSSocket.emit (events.js:104:17)
```