### PR TITLE
[refactor,fix] statusText for complete; simplify callbacks like jQuery

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -123,7 +123,6 @@ function najax (uri, options, callback) {
   function errorHandler (e) {
     // Set data for the fake xhr object
     jqXHR.responseText = e.stack
-    if (_.isFunction(o.error)) o.error(jqXHR, 'error', e)
     // jqXHR, statusText, error
     dfd.reject(jqXHR, 'error', e)
   }
@@ -171,8 +170,6 @@ function najax (uri, options, callback) {
       if (isSuccess) {
         // Set data for the fake xhr object
         jqXHR.statusText = statusText
-
-        if (_.isFunction(o.success)) o.success(data, statusText, jqXHR)
         // success, statusText, jqXHR
         dfd.resolve(data, statusText, jqXHR)
       } else {
@@ -180,11 +177,8 @@ function najax (uri, options, callback) {
         // When an HTTP error occurs, errorThrown receives the textual portion of the
         // HTTP status, such as "Not Found" or "Internal Server Error."
         statusText = 'error'
-        if (_.isFunction(o.error)) o.error(jqXHR, statusText, http.STATUS_CODES[statusCode])
         dfd.reject(jqXHR, statusText, http.STATUS_CODES[statusCode])
       }
-
-      if (_.isFunction(o.complete)) o.complete(jqXHR)
     })
   })
 
@@ -193,13 +187,9 @@ function najax (uri, options, callback) {
 
   // SET TIMEOUT
   if (o.timeout && o.timeout > 0) {
-    req.on('socket', function (socket) {
-      socket.setTimeout(o.timeout)
-      socket.on('timeout', function () {
-        req.abort()
-        if (_.isFunction(o.error)) o.error(jqXHR, 'timeout')
-        dfd.reject(jqXHR, 'timeout')
-      })
+    req.setTimeout(o.timeout, function () {
+      req.abort()
+      dfd.reject(jqXHR, 'timeout')
     })
   }
 
@@ -208,6 +198,10 @@ function najax (uri, options, callback) {
   req.end()
 
   // DEFERRED
+  dfd.done(o.success)
+  dfd.done(o.complete)
+  dfd.fail(o.error)
+  dfd.fail(o.complete)
   dfd.success = dfd.done
   dfd.error = dfd.fail
   return dfd

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -29,12 +29,6 @@ describe('method overloads', function (next) {
       error: error
     })
   })
-
-  it('should call complete when finished', function (done) {
-    najax({ url: 'http://www.example.com', complete: function () {
-      done()
-    }})
-  })
 })
 
 describe('url', function (next) {
@@ -262,6 +256,17 @@ describe('timeout', function () {
         expect(statusText).to.eql('timeout')
         done()
       })
+  })
+  it('should call complete with status when finished', function (done) {
+    nock('http://www.example.com')
+      .post('/')
+      .socketDelay(1000)
+      .reply(200, 'ok')
+    var opts = { timeout: 1, error: false, complete: function (jqXHR, statusText) {
+      expect(statusText).to.eql('timeout')
+      done()
+    }}
+    najax.post('http://www.example.com', opts)
   })
 })
 


### PR DESCRIPTION
* In order to make #28 fully [compatible with jQuery](http://api.jquery.com/jquery.ajax/#jQuery-ajax-settings), we need to pass a `statusText` as the 2nd arg to the `complete` callback.
* When writing a new test I discovered that `'timeout'` status was not being relayed to the `complete`callback.
* Also investigating timeouts, we can set the callback and timeout with a single call to [`request.setTimeout`](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
* Lastly while looking over the jQuery source, I see we can [condense multiple callbacks by adding them to the jqXHR deferred callback set](https://github.com/jquery/jquery/blob/93a8fa6bfc1c8a469e188630b61e736dfb69e128/src/ajax.js#L659).