### PR TITLE
Method should default to "GET" if not specified (Fix #41)

### DIFF
--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -15,7 +15,9 @@ module.exports = function parseOptions (url, options, callback) {
   }
 
   // support legacy jquery options.type
-  opts.method = opts.method || opts.type
+  if (!opts.method && opts.type) {
+    opts.method = opts.type
+  }
 
   return opts
 }

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -30,6 +30,14 @@ describe('method overloads', function (next) {
       error: error
     })
   })
+
+  it('should default to "GET" for the method if not specified', function () {
+    var debug = najax({
+      url: 'http://www.example.com',
+      getopts: true
+    })
+    expect(debug[1].method).to.eql('GET')
+  })
 })
 
 describe('url', function (next) {

--- a/test/test-parse-options.js
+++ b/test/test-parse-options.js
@@ -1,0 +1,29 @@
+/* globals describe it */
+var parseOptions = require('../lib/parse-options.js')
+var expect = require('chai').expect
+
+const exampleUrl = 'http://www.example.com/'
+
+describe('method parsing', function () {
+  it('should not define a method by default', function () {
+    var opts = parseOptions({ url: exampleUrl })
+    expect(Object.keys(opts).indexOf('method')).to.eql(-1)
+  })
+
+  it('should support legacy "type" option', function () {
+    var opts = parseOptions({ type: 'DELETE', url: exampleUrl })
+    expect(opts.method).to.eql('DELETE')
+  })
+})
+
+describe('mixed argument support', function () {
+  it('should support urls as the 1st argument', function () {
+    var opts = parseOptions(exampleUrl)
+    expect(opts.url).to.eql(exampleUrl)
+  })
+
+  it('should support a success callback as the 2nd argument', function () {
+    var opts = parseOptions(exampleUrl, function () {})
+    expect(typeof opts.success).to.eql('function')
+  })
+})


### PR DESCRIPTION
The wrong lodash method was being used. While researching #41, I discovered that [the intent of this library was to default to `GET`](https://github.com/najaxjs/najax/blob/2caeb5437dc78476de5a86b90157f8836051fcbb/lib/najax.js#L15), but [_.extend / _.assign was being used to parse options](http://stackoverflow.com/a/24610079/270302), which left `method` `undefined`.

This PR fixes that and adds a test to ensure it doesn't break again.