### PR TITLE
Better emulate jQuery by resolving successful request on JSON parse error

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -138,7 +138,11 @@ function najax (uri, options, callback) {
         try {
           data = JSON.parse(data.replace(/[\cA-\cZ]/gi, ''))
         } catch (e) {
-          return onError(e)
+          //emulate jQuery functionality (replace data with JSON parse error)
+          data = {
+            state: 'parsererror',
+            error: 'Failed to parse JSON string: ' + e.message
+          }
         }
       }
 

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -366,7 +366,7 @@ function jsonSuccess (done) {
 
 function jsonError (done) {
   return function (data, statusText) {
-    expect(data.test).to.be.undefined
+    expect(data.state).to.equal('parsererror')
     expect(statusText).to.equal('success')
     done()
   }

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -90,7 +90,7 @@ describe('url', function (next) {
   it('should succeed when result is good JSON', function (done) {
     nock('http://www.example.com')
       .get('/')
-      .reply(200, {"test": "ok"})
+      .reply(200, {'test': 'ok'})
 
     najax({url: 'http://www.example.com', dataType: 'json'}, jsonSuccess(done))
   })

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -73,6 +73,14 @@ describe('url', function (next) {
   }
 
   it('should accept plain URL', function (done) {
+    // An extra nock seems to be being
+    // registered and affecting the subsequent tests
+    // (I beleive it is caused by:
+    // https://github.com/najaxjs/najax/commit/54cfac6aa0b7cf8a89efae0f39d1f054c8859de0
+    // commenting out the 'default to "GET"' test also fixes this)
+    // make an extra call to najax in order to clear it
+    najax({url: 'http://www.example.com'})
+
     mockPlain('get')
     najax('http://www.example.com', createSuccess(done))
   })

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -82,6 +82,19 @@ describe('url', function (next) {
     najax({ url: 'http://www.example.com' }, createSuccess(done))
   })
 
+  it('should not fail when result is broken JSON', function (done) {
+    mockPlain('get')
+    najax({url: 'http://www.example.com', dataType: 'json'}, jsonError(done))
+  })
+
+  it('should succeed when result is good JSON', function (done) {
+    nock('http://www.example.com')
+      .get('/')
+      .reply(200, {"test": "ok"})
+
+    najax({url: 'http://www.example.com', dataType: 'json'}, jsonSuccess(done))
+  })
+
   it('should parse auth from the url', function (done) {
     mockAuth('get')
     najax({ url: 'http://' + authString + '@www.example.com' }, createSuccess(done))
@@ -338,6 +351,22 @@ describe('headers', function () {
 function createSuccess (done) {
   return function (data, statusText) {
     expect(data).to.equal('ok')
+    expect(statusText).to.equal('success')
+    done()
+  }
+}
+
+function jsonSuccess (done) {
+  return function (data, statusText) {
+    expect(data.test).to.equal('ok')
+    expect(statusText).to.equal('success')
+    done()
+  }
+}
+
+function jsonError (done) {
+  return function (data, statusText) {
+    expect(data.test).to.be.undefined
     expect(statusText).to.equal('success')
     done()
   }


### PR DESCRIPTION
In jQuery: when a successful ajax requests with datatype json has a body that can't be parsed, jQuery will replace the data with a custom error object and treat it as a successful request (resolve promise). 

This has the effect of ignoring JSON parse errors for unsuccessful quests (e.g. a 401 where the response data is never passed to a handler).

Currently, najax will instead reject the promise, treating it as an unsuccessful request.

This has the effect of throwing a parse error when an unsuccessful request fails to return JSON, meaning the actual request error is covered up.