### PR TITLE
Fix unable to merge default options

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -229,7 +229,7 @@ function najax (uri, options, callback) {
   return dfd
 }
 
-najax.defaults = function defaults (opts) {
+najax.defaults = function (opts) {
   return _.extend(defaults, opts)
 }
 


### PR DESCRIPTION
Local definition of function overrides local variable for `defaults` of the same name. Thus, `_.extend` was merging new defaults into the function `defaults` rather than the object `defaults`.