### PR TITLE
Mimic how jquery handles array parameters with GET

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -41,8 +41,7 @@ function najax (uri, options, callback) {
   // and the data is not already a string
   // https://github.com/jquery/jquery/blob/master/src/ajax.js#L518
   if (o.data && o.processData && o.method === 'GET') {
-
-    o.data = querystring.stringify(o.data, { arrayFormat: 'brackets' });
+    o.data = querystring.stringify(o.data, { arrayFormat: 'brackets' })
   } else if (o.data && o.processData && typeof o.data !== 'string' && o.method !== 'GET') {
     switch (o.contentType) {
       case 'application/json':

--- a/lib/najax.js
+++ b/lib/najax.js
@@ -41,7 +41,8 @@ function najax (uri, options, callback) {
   // and the data is not already a string
   // https://github.com/jquery/jquery/blob/master/src/ajax.js#L518
   if (o.data && o.processData && o.method === 'GET') {
-    o.data = querystring.stringify(o.data)
+
+    o.data = querystring.stringify(o.data, { arrayFormat: 'brackets' });
   } else if (o.data && o.processData && typeof o.data !== 'string' && o.method !== 'GET') {
     switch (o.contentType) {
       case 'application/json':

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -200,6 +200,19 @@ describe('data', function (next) {
     }, createSuccess(done))
   })
 
+  describe('data containing array', function() {
+    var arrayData = {a: [1, 2, 3]};
+    // url encoded: ?a[]=1&a[]=2&a[]=3
+    var encodedArrayData = '?a%5B%5D=1&a%5B%5D=2&a%5B%5D=3';
+
+    it('should encode array with empty bracket syntax', function(done) {
+      nock('http://www.example.com').get('/' + encodedArrayData).reply(200, 'ok');
+      najax.get('http://www.example.com', {
+        data: arrayData
+      }, createSuccess(done))
+    });
+  });
+
   it('should pass correct headers for x-www-form-urlencoded data', function (done) {
     nock('http://www.example.com')
       .post('/', 'a=1')

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -200,18 +200,18 @@ describe('data', function (next) {
     }, createSuccess(done))
   })
 
-  describe('data containing array', function() {
-    var arrayData = {a: [1, 2, 3]};
+  describe('data containing array', function () {
+    var arrayData = {a: [1, 2, 3]}
     // url encoded: ?a[]=1&a[]=2&a[]=3
-    var encodedArrayData = '?a%5B%5D=1&a%5B%5D=2&a%5B%5D=3';
+    var encodedArrayData = '?a%5B%5D=1&a%5B%5D=2&a%5B%5D=3'
 
-    it('should encode array with empty bracket syntax', function(done) {
-      nock('http://www.example.com').get('/' + encodedArrayData).reply(200, 'ok');
+    it('should encode array with empty bracket syntax', function (done) {
+      nock('http://www.example.com').get('/' + encodedArrayData).reply(200, 'ok')
       najax.get('http://www.example.com', {
         data: arrayData
       }, createSuccess(done))
-    });
-  });
+    })
+  })
 
   it('should pass correct headers for x-www-form-urlencoded data', function (done) {
     nock('http://www.example.com')


### PR DESCRIPTION
I discovered this behaving differently than jQuery while using Ember Fastboot.

This PR allows arrays to be serialized the same way $.param does:  `{a: [1,2,3]}` becomes `?a[]=1&a[]=2&a[]=3`

The old way: `?a[0]=1&a[1]=2&a[2]=3`