### PR TITLE
Fix bad json error handling,  test error states

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -136,14 +136,7 @@ function najax (uri, options, callback) {
       jqXHR.responseText = data
 
       var statusCode = res.statusCode
-      jqXHR.statusText = 'success'
-
-      if (statusCode === 204 || options.method === 'HEAD') {
-        jqXHR.statusText = 'nocontent'
-      } else if (statusCode === 304) {
-        jqXHR.statusText = 'notmodified'
-      }
-
+      //
       // Determine if successful
       // (per https://github.com/jquery/jquery/blob/master/src/ajax.js#L679)
       var isSuccess = statusCode >= 200 && statusCode < 300 || statusCode === 304
@@ -156,11 +149,20 @@ function najax (uri, options, callback) {
         try {
           data = JSON.parse(data.replace(/[\cA-\cZ]/gi, ''))
         } catch (e) {
+          jqXHR.statusText = 'parseerror'
           return onError(e)
         }
       }
 
       if (isSuccess) {
+        jqXHR.statusText = 'success'
+
+        if (statusCode === 204 || options.method === 'HEAD') {
+          jqXHR.statusText = 'nocontent'
+        } else if (statusCode === 304) {
+          jqXHR.statusText = 'notmodified'
+        }
+
         // success, statusText, jqXHR
         dfd.resolve(data, jqXHR.statusText, jqXHR)
       } else {
@@ -202,8 +204,6 @@ function najax (uri, options, callback) {
   req.on('error', onError)
 
   function onError (e) {
-    // Set data for the fake xhr object
-    if (jqXHR.statusText === 'error') jqXHR.responseText = e.stack
     // jqXHR, statusText, error
     dfd.reject(jqXHR, jqXHR.statusText, e)
   }

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -384,6 +384,90 @@ describe('defaults', function () {
   })
 })
 
+describe('errors', function () {
+  describe('error response codes', function () {
+    [400, 422, 500, 502].forEach(function (code) {
+      describe('Status code: ' + code, function () {
+        it('should trigger promise fail', function (done) {
+          nock('http://example.com').post('/').reply(code, 'An Error Occurred... Details here')
+
+          najax({url: 'http://example.com', type: 'POST'}).fail(function (jqXHR, statusText, error) {
+            expect(jqXHR.status).to.equal(code)
+            expect(jqXHR.responseText).to.equal('An Error Occurred... Details here')
+
+            expect(statusText).to.equal('error')
+            expect(error).to.be.an('error')
+
+            done()
+          })
+        })
+
+        describe('error callback given', function () {
+          it('should trigger callback', function (done) {
+            nock('http://example.com').post('/').reply(code, 'An Error Occurred... Details here')
+
+            najax({
+              url: 'http://example.com',
+              type: 'POST',
+              error: function (jqXHR, statusText, error) {
+                expect(jqXHR.status).to.equal(code)
+                expect(jqXHR.responseText).to.equal('An Error Occurred... Details here')
+
+                expect(statusText).to.equal('error')
+                expect(error).to.be.an('error')
+
+                done()
+              }
+            })
+          })
+        })
+      })
+    })
+  })
+
+  describe('error parsing json response', function () {
+    var options = {
+      url: 'http://example.com',
+      dataType: 'json',
+      method: 'POST'
+    }
+
+    var response = '<div>Not Json</div>'
+
+    it('should trigger promise fail', function (done) {
+      nock('http://example.com').post('/').reply(200, response)
+
+      najax(options).fail(function (jqXHR, statusText, error) {
+        expect(jqXHR.status).to.equal(200)
+        expect(jqXHR.responseText).to.equal(response)
+
+        expect(statusText).to.equal('parseerror')
+        expect(error).to.be.instanceOf(SyntaxError)
+
+        done()
+      })
+    })
+
+    describe('error callback given', function () {
+      it('should trigger callback', function (done) {
+        nock('http://example.com').post('/').reply(200, response)
+
+        najax(Object.assign({}, options, {
+          error: function (jqXHR, statusText, error) {
+            expect(jqXHR.status).to.equal(200)
+            expect(jqXHR.responseText).to.equal(response)
+
+            expect(statusText).to.equal('parseerror')
+            expect(error).to.be.instanceOf(SyntaxError)
+
+            done()
+          }
+        }))
+      })
+    })
+  })
+})
+
 function createSuccess (done) {
   return function (data, statusText) {
     expect(data).to.equal('ok')

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -388,20 +388,6 @@ describe('errors', function () {
   describe('error response codes', function () {
     [400, 422, 500, 502].forEach(function (code) {
       describe('Status code: ' + code, function () {
-        it('should trigger promise fail', function (done) {
-          nock('http://example.com').post('/').reply(code, 'An Error Occurred... Details here')
-
-          najax({url: 'http://example.com', type: 'POST'}).fail(function (jqXHR, statusText, error) {
-            expect(jqXHR.status).to.equal(code)
-            expect(jqXHR.responseText).to.equal('An Error Occurred... Details here')
-
-            expect(statusText).to.equal('error')
-            expect(error).to.be.an('error')
-
-            done()
-          })
-        })
-
         describe('error callback given', function () {
           it('should trigger callback', function (done) {
             nock('http://example.com').post('/').reply(code, 'An Error Occurred... Details here')
@@ -433,20 +419,6 @@ describe('errors', function () {
     }
 
     var response = '<div>Not Json</div>'
-
-    it('should trigger promise fail', function (done) {
-      nock('http://example.com').post('/').reply(200, response)
-
-      najax(options).fail(function (jqXHR, statusText, error) {
-        expect(jqXHR.status).to.equal(200)
-        expect(jqXHR.responseText).to.equal(response)
-
-        expect(statusText).to.equal('parseerror')
-        expect(error).to.be.instanceOf(SyntaxError)
-
-        done()
-      })
-    })
 
     describe('error callback given', function () {
       it('should trigger callback', function (done) {


### PR DESCRIPTION
From my testing with jQuery:  jQuery will trigger the error callback with an untouched jqXHR object, a statusText of 'parseerror', and a SyntaxError - when it can't parse the response json.

This PR does a couple things:
1. it mimics the way jQuery would respond when it can't parse json
2. it preserves the original responseText, since the error argument will contain the stacktrace, and the responseText is sometimes essential to understanding what went wrong.
3. Tests for error states to ensure expected arguments and context are passed to error handlers
