### PR TITLE
Fix persistent headers bug

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -231,7 +231,7 @@ function najax (uri, options, callback) {
 }
 
 najax.defaults = function mergeDefaults (opts) {
-  return Object.assign({}, defaults, opts)
+  return Object.assign(defaults, opts)
 }
 
 /* auto rest interface go! */

--- a/lib/najax.js
+++ b/lib/najax.js
@@ -9,6 +9,7 @@ var querystring = require('qs')
 var url = require('url')
 var zlib = require('zlib')
 var $ = require('jquery-deferred')
+var defaultsDeep = require('lodash.defaultsdeep')
 var parseOptions = require('./parse-options')
 var defaults = {
   method: 'GET',
@@ -30,7 +31,7 @@ var defaults = {
 */
 function najax (uri, options, callback) {
   var dfd = new $.Deferred()
-  var o = Object.assign({}, defaults, parseOptions(uri, options, callback))
+  var o = defaultsDeep({}, parseOptions(uri, options, callback), defaults)
   var l = url.parse(o.url)
   var ssl = l.protocol.indexOf('https') === 0
 
@@ -231,7 +232,7 @@ function najax (uri, options, callback) {
 }
 
 najax.defaults = function mergeDefaults (opts) {
-  return Object.assign(defaults, opts)
+  return defaultsDeep(defaults, opts)
 }
 
 /* auto rest interface go! */
@@ -239,7 +240,7 @@ najax.defaults = function mergeDefaults (opts) {
 
 function handleMethod (method) {
   najax[method.toLowerCase()] = function methodHandler (uri, options, callback) {
-    return najax(Object.assign(parseOptions(uri, options, callback), { method: method }))
+    return najax(defaultsDeep(parseOptions(uri, options, callback), { method: method }))
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "keywords": [],
   "dependencies": {
     "jquery-deferred": "^0.3.0",
+    "lodash.defaultsdeep": "^4.6.0",
     "qs": "^6.2.0"
   },
   "directories": {

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -348,6 +348,42 @@ describe('headers', function () {
   })
 })
 
+describe('defaults', function () {
+  function mockResponse () {
+    nock('http://www.example.com')
+      .get('/')
+      .reply(function (uri, requestBody) {
+        if (this.req.headers.accessible) {
+          return [200, 'ok', {}]
+        } else {
+          return [401, 'Unauthorized', {}]
+        }
+      })
+  }
+
+  it('should dispose of request headers after each request', function (done) {
+    mockResponse()
+    najax.get('http://www.example.com', {
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('accessible', 'true')
+      },
+      complete: function (data, statusText, jqXHR) {
+        expect(jqXHR.status).to.equal(200)
+      }
+    })
+
+    mockResponse()
+    najax.get('http://www.example.com', {
+      error: null,
+      complete: function (jqXHR, statusText, error) {
+        expect(jqXHR, 'request should not succeed').to.be.an('object')
+        expect(jqXHR.status).to.equal(401)
+        done()
+      }
+    })
+  })
+})
+
 function createSuccess (done) {
   return function (data, statusText) {
     expect(data).to.equal('ok')


### PR DESCRIPTION
This PR fixes #50 and https://github.com/ember-fastboot/fastboot/issues/104. #54 tried to fix it too, but the test case was still failing afterwards.

This PR:

- imports the test case into the test suite (thanks @DrewCarlson!)
- reverts #54 as it was not working as intended
- fixes #50 by using [`_.defaultsDeep()`](https://lodash.com/docs/#defaultsDeep) instead of `Object.assign()`

The issue was that `o.headers` always pointed to the same hash as `defaults.headers` and modifying `o.headers` via `setRequestHeader()` caused `defaults.headers` to be modified.

/cc @rwjblue @mike-north @marcoow