### PR TITLE
Correctly encode post data contentType including charset

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -43,11 +43,11 @@ function najax (uri, options, callback) {
   if (o.data && o.processData && o.method === 'GET') {
     o.data = querystring.stringify(o.data, { arrayFormat: 'brackets' })
   } else if (o.data && o.processData && typeof o.data !== 'string' && o.method !== 'GET') {
-    switch (o.contentType) {
-      case 'application/json':
+    switch (true) {
+      case o.contentType.startsWith('application/json'):
         o.data = JSON.stringify(o.data)
         break
-      case 'application/x-www-form-urlencoded':
+      case o.contentType.startsWith('application/x-www-form-urlencoded'):
         o.data = querystring.stringify(o.data)
         break
       default:

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -223,6 +223,18 @@ describe('data', function (next) {
     najax.post('http://www.example.com', { data: data }, createSuccess(done))
   })
 
+  it('should encode data for x-www-form-urlencoded with charset', function (done) {
+    nock('http://www.example.com')
+      .post('/', 'a=1')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded; charset=utf-8')
+      .reply(200, 'ok')
+
+    najax.post('http://www.example.com', {
+      data: data,
+      contentType: 'application/x-www-form-urlencoded; charset=utf-8'
+    }, createSuccess(done))
+  })
+
   it('should support nested urlencoded objects, because you could just content-type=json but yolo', function (done) {
     nock('http://www.example.com')
       .post('/', 'a=1&b%5Bc%5D=1')


### PR DESCRIPTION
When passing `application/x-www-form-urlencoded; charset=utf-8` as `contentType` for POST requests data isn't correctly encoded. Data is casted to String instead of being urlEncoded.

This PR allows passing charset in `contentType` and properly encodes data.