### PR TITLE
Parse data as JSON when content type is application/json

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -144,7 +144,7 @@ function najax (uri, options, callback) {
       jqXHR.readyState = statusCode > 0 ? 4 : 0
       jqXHR.status = statusCode
 
-      if (o.dataType === 'json' || o.dataType === 'jsonp') {
+      if (o.dataType === 'json' || o.dataType === 'jsonp' || (res.headers['content-type'] || '').startsWith('application/json')) {
         // replace control characters
         try {
           data = JSON.parse(data.replace(/[\cA-\cZ]/gi, ''))

--- a/test/test-najax.js
+++ b/test/test-najax.js
@@ -304,6 +304,21 @@ describe('data', function (next) {
       }
     }, createSuccess(done))
   })
+
+  it('should parse the response as json if the response content-type is application/json', function(done) {
+    nock('http://www.example.com')
+      .get('/')
+      .reply(200, {some: 'json'}, {
+        'Content-Type': 'application/json; charset=utf-8'
+      })
+
+    najax.get('http://www.example.com', function (data, statusText) {
+      expect(data.some).to.equal('json')
+      expect(statusText).to.equal('success')
+      done()
+    })
+
+  })
 })
 
 describe('timeout', function () {


### PR DESCRIPTION
This PR improves the way the response data type is inferred. 

Problem: JSON data is not parsed unless the `dataType` property is set explicitly to `json` or `jsonp`.

jQuery specs for the `dataType` property: 

>The type of data that you're expecting back from the server. If none is specified, jQuery will try to infer it based on the MIME type of the response (an XML MIME type will yield XML, in 1.4 JSON will yield a JavaScript object, in 1.4 script will execute the script, and anything else will be returned as a string).

This PR adds parsing of the response data when the Content-Type response header is `application/json`, which would more closely mimic the original behaviour of jQuery. 

Side note: Tests seem to be broken in master, I added mine, but there were several old tests that don't pass. 