### PR TITLE
Fix pass through of keep-alive agent. Fixes #61

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -92,9 +92,9 @@ function najax (uri, options, callback) {
   } else if (o.auth) {
     options.auth = o.auth
   }
+  /* pass keep-alive agent if provided */
+  if (o.agent) options.agent = o.agent
 
-  if (options.auth) o.auth = options.auth
-  if (options.agent) o.agent = options.agent
   /* for debugging, method to get options and return */
   if (o.getopts) {
     var getopts = [ssl, options, o.data || false, o.success || false, o.error || false]


### PR DESCRIPTION
Fixes https://github.com/najaxjs/najax/issues/61

Currently there is no way to pass through the 'agent' property from 'options' to xhr request making keep-alive impossible. It was passible in pre 1.x released. Likely an an oversight. 

**Expected:**

If the 'agent'  is specified in provided 'options' it should be passed through to xhr.

Please approve.