### PR TITLE
Pass timeout parameter to request

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -92,8 +92,12 @@ function najax (uri, options, callback) {
   } else if (o.auth) {
     options.auth = o.auth
   }
+
   /* pass keep-alive agent if provided */
   if (o.agent) options.agent = o.agent
+
+  /* pass request timeout */
+  if (o.timeout) options.timeout = o.timeout;
 
   /* for debugging, method to get options and return */
   if (o.getopts) {


### PR DESCRIPTION
Similar to #64

timeout option is allowed in node's http request:
`http.request({url: 'http://localhost, timeout: 3000})`
ref https://nodejs.org/api/http.html#http_http_request_options_callback

timeout is also a correct option for jquery.ajax()

Tested on node 8.9 and latest 10.8.0